### PR TITLE
[#124] Don't build and deploy the documentation on PR to master, since useless and might cause issues

### DIFF
--- a/.github/workflows/antoradoc.yml
+++ b/.github/workflows/antoradoc.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: 
       - master
-  pull_request:
-    branches: 
-      - master
 env:
   SITE_DIR: 'site'
 jobs:

--- a/docs/modules/ROOT/pages/CHANGELOG.adoc
+++ b/docs/modules/ROOT/pages/CHANGELOG.adoc
@@ -6,6 +6,10 @@
 
 * Document how to write documentation in this project https://github.com/camptocamp/camptocamp-devops-stack/pull/122[#122] (https://github.com/acampergue-camptocamp[acampergue-camptocamp]), closes https://github.com/camptocamp/camptocamp-devops-stack/issues/107[issue #107].
 
+*Fixed bugs:*
+
+* Don't build and deploy the documentation on PR to master, since useless and might cause issues https://github.com/camptocamp/camptocamp-devops-stack/pull/128[#128] (https://github.com/acampergue-camptocamp[acampergue-camptocamp]), closes https://github.com/camptocamp/camptocamp-devops-stack/issues/124[issue #124]
+
 == https://github.com/camptocamp/camptocamp-devops-stack/tree/v0.4.0[0.4.0] (2020-10-10)
 
 https://github.com/camptocamp/camptocamp-devops-stack/compare/v0.3.0...v0.4.0[Full Changelog]


### PR DESCRIPTION
[#124] Don't build and deploy the documentation on PR to master, since useless and might cause issues