### PR TITLE
[#107] Add link to AsciiDoc Syntax Quick Reference on top of Asciidoc Cheatsheet

### DIFF
--- a/docs/modules/ROOT/pages/CHANGELOG.adoc
+++ b/docs/modules/ROOT/pages/CHANGELOG.adoc
@@ -4,7 +4,7 @@
 
 *Documentation:*
 
-* Document how to write documentation in this project https://github.com/camptocamp/camptocamp-devops-stack/pull/122[#122] (https://github.com/acampergue-camptocamp[acampergue-camptocamp]), closes https://github.com/camptocamp/camptocamp-devops-stack/issues/107[issue #107].
+* Document how to write documentation in this project https://github.com/camptocamp/camptocamp-devops-stack/pull/122[#122] and https://github.com/camptocamp/camptocamp-devops-stack/pull/132[#132] (https://github.com/acampergue-camptocamp[acampergue-camptocamp]), closes https://github.com/camptocamp/camptocamp-devops-stack/issues/107[issue #107].
 
 *Fixed bugs:*
 

--- a/docs/modules/ROOT/pages/how_to_write_doc.adoc
+++ b/docs/modules/ROOT/pages/how_to_write_doc.adoc
@@ -9,7 +9,7 @@ The documentation of this project is located into the `docs/` folder and has to 
 To write a new page of documentation, create a new file inside the `docs\modules\ROOT\pages` subfolder, with the `.adoc` extension.
 You should then write your content using https://asciidoc.org/[Asciidoc language].
 
-TIP: Use this https://powerman.name/doc/asciidoc[Asciidoc Cheatsheet]
+TIP: Use the https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc Syntax Quick Reference] and the https://powerman.name/doc/asciidoc[Asciidoc Cheatsheet]
 
 === Convert an existing Markdown document
 


### PR DESCRIPTION
[#107] Add link to AsciiDoc Syntax Quick Reference on top of Asciidoc Cheatsheet

I originally added this link in the first branch but lost it before pushing it, re-adding it now.