### PR TITLE
Update Antora doc version

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: camptocamp-devops-stack
 title: Camptocamp’s DevOps stack
-version: 0.3.0
+version: 0.4.1
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
We forgot to update the Antora doc version number before tagging, it screws up the meta documentation because all versions are merged into one under the v0.3.0 