### PR TITLE
Correct deprecation warning during Antora build

### DIFF
--- a/.github/workflows/antoradoc.yml
+++ b/.github/workflows/antoradoc.yml
@@ -31,9 +31,9 @@ jobs:
     name: "Deploy GitHub Pages"
     steps:
      - name: Setup Node.js for use with actions
-       uses: actions/setup-node@v1.1.0
+       uses: actions/setup-node@v1.4.4
        with:
-         version: 12.x
+         node-version: 12.x
      - name: Checkout
        uses: actions/checkout@v2
      - name: Download generated site


### PR DESCRIPTION
Upgrade version of actions/setup-node to 1.4.4, replace version by node-version