### PR TITLE
Fix Grafana with Prometheus (no proxy)

### DIFF
--- a/modules/eks-aws/values.tmpl.yaml
+++ b/modules/eks-aws/values.tmpl.yaml
@@ -118,7 +118,7 @@ kube-prometheus-stack:
           name: prometheus-proxy
           ports:
             - containerPort: 9091
-              name: web
+              name: proxy
     ingress:
       enabled: true
       annotations:
@@ -135,6 +135,16 @@ kube-prometheus-stack:
             - prometheus.apps.${cluster_name}.${base_domain}
 
   grafana:
+    # Required to use oauth2_proxy on Prometheus
+    sidecar:
+      datasources:
+        defaultDatasourceEnabled: false
+    additionalDataSources:
+      - name: Prometheus
+        type: prometheus
+        url: http://cluster-monitoring-kube-pr-prometheus:9090/
+        access: proxy
+        isDefault: true
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
This seems to be the only way to support both the oauth2 proxy for Prometheus and the default backend in Grafana.

The reason is that `prometheus.service.port` is used for both in the chart, without a way to override either separately:

 - https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/service.yaml#L40
 - https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml#L22
 - https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml#L3

So:
 - we need to modify the Prometheus service port in order to change it in the Ingress
 - but we need to avoid the proxy for the grafana data source

=> the only option is to deactivate the default data source and feed one manually
