### PR TITLE
Add OAuth to Grafana

### DIFF
--- a/modules/eks-aws/cognito.tf
+++ b/modules/eks-aws/cognito.tf
@@ -23,7 +23,7 @@ resource "aws_cognito_user_pool_client" "client" {
 
   callback_urls = [
     format("https://argocd.apps.%s.%s/auth/callback", var.cluster_name, var.base_domain),
-    format("https://grafana.apps.%s.%s/auth/callback", var.cluster_name, var.base_domain),
+    format("https://grafana.apps.%s.%s/login/generic_oauth", var.cluster_name, var.base_domain),
     format("https://prometheus.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
     format("https://alertmanager.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
   ]

--- a/modules/eks-aws/main.tf
+++ b/modules/eks-aws/main.tf
@@ -143,6 +143,7 @@ resource "helm_release" "app_of_apps" {
         cognito_user_pool_id            = var.cognito_user_pool_id
         cognito_user_pool_client_id     = aws_cognito_user_pool_client.client.id
         cognito_user_pool_client_secret = aws_cognito_user_pool_client.client.client_secret
+        cognito_user_pool_domain        = aws_cognito_user_pool_domain.this.domain
         cookie_secret                   = random_password.oauth2_cookie_secret.result
         enable_efs                      = var.enable_efs
         efs_filesystem_id               = var.enable_efs ? module.efs.0.this_efs_mount_target_file_system_id : ""
@@ -155,4 +156,9 @@ resource "helm_release" "app_of_apps" {
   depends_on = [
     helm_release.argocd,
   ]
+}
+
+resource "aws_cognito_user_pool_domain" "this" {
+  domain       = var.cluster_name
+  user_pool_id = var.cognito_user_pool_id
 }

--- a/modules/eks-aws/values.tmpl.yaml
+++ b/modules/eks-aws/values.tmpl.yaml
@@ -146,14 +146,35 @@ kube-prometheus-stack:
             - prometheus.apps.${cluster_name}.${base_domain}
 
   grafana:
-    # Required to use oauth2_proxy on Prometheus
-    sidecar.datasources.defaultDatasourceEnabled: false
-    additionalDataSources: |
+    grafana.ini:
+      auth.generic_oauth:
+        name: Cognito
+        enabled: true
+        allow_sign_up: true
+        client_id: ${cognito_user_pool_client_id}
+        client_secret: ${cognito_user_pool_client_secret}
+        scopes: "openid profile email"
+        auth_url: https://${cognito_user_pool_domain}.auth.${aws_default_region}.amazoncognito.com/oauth2/authorize
+        token_url: https://${cognito_user_pool_domain}.auth.${aws_default_region}.amazoncognito.com/oauth2/token
+        api_url: https://${cognito_user_pool_domain}.auth.${aws_default_region}.amazoncognito.com/oauth2/userInfo
+      server:
+        domain: grafana.apps.${cluster_name}.${base_domain}
+        root_url: "https://%(domain)s"
+    sidecar:
+      datasources:
+        defaultDatasourceEnabled: false
+    additionalDataSources:
       - name: Prometheus
         type: prometheus
+        # TODO: fix this 9091 with oauthPassThru
+        #url: http://cluster-monitoring-kube-pr-prometheus:9091/
         url: http://cluster-monitoring-kube-pr-prometheus:9090/
         access: proxy
         isDefault: true
+        jsonData:
+          tlsAuth: false
+          tlsAuthWithCACert: false
+          oauthPassThru: true
     ingress:
       enabled: true
       annotations:

--- a/modules/eks-aws/values.tmpl.yaml
+++ b/modules/eks-aws/values.tmpl.yaml
@@ -129,7 +129,7 @@ kube-prometheus-stack:
           name: prometheus-proxy
           ports:
             - containerPort: 9091
-              name: web
+              name: proxy
     ingress:
       enabled: true
       annotations:
@@ -146,6 +146,14 @@ kube-prometheus-stack:
             - prometheus.apps.${cluster_name}.${base_domain}
 
   grafana:
+    # Required to use oauth2_proxy on Prometheus
+    sidecar.datasources.defaultDatasourceEnabled: false
+    additionalDataSources: |
+      - name: Prometheus
+        type: prometheus
+        url: http://cluster-monitoring-kube-pr-prometheus:9090/
+        access: proxy
+        isDefault: true
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
This uses Cognito to add OAuth to Grafana.

Ideally, we should be able to forward the OAuth token to Prometheus, but it doesn't seem to work in my tests at the moment. I don't know if it's due to oauth2_proxy.
