### PR TITLE
Instantiate the app of apps inside the argocd-helm module

### DIFF
--- a/argocd/app-of-apps/values.tmpl.yaml
+++ b/argocd/app-of-apps/values.tmpl.yaml
@@ -21,9 +21,9 @@ apps:
   csi-secrets-store-provider-azure:
     enabled: false
   efs-provisioner:
-    enabled: ${enable_efs}
+    enabled: ${efs_provisioner.enable}
   keycloak:
-    enabled: ${enable_keycloak}
+    enabled: ${keycloak.enable}
   kube-prometheus-stack:
     enabled: true
   loki-stack:
@@ -31,11 +31,11 @@ apps:
   metrics-server:
     enabled: true
   minio:
-    enabled: ${enable_minio}
+    enabled: ${minio.enable}
   namespaces:
     enabled: true
   olm:
-    enabled: ${enable_olm}
+    enabled: ${olm.enable}
   secrets-store-csi-driver:
     enabled: false
   traefik:
@@ -49,7 +49,7 @@ argo-cd:
   configs:
     secret:
       extra:
-        oidc.default.clientSecret: ${client_secret}
+        oidc.default.clientSecret: ${oidc.client_secret}
         accounts.pipeline.tokens: '${argocd_accounts_pipeline_tokens}'
   controller:
     metrics:
@@ -65,8 +65,8 @@ argo-cd:
       url: https://argocd.apps.${cluster_name}.${base_domain}
       oidc.config: |
         name: OIDC
-        issuer: ${oidc_issuer_url}
-        clientID: ${client_id}
+        issuer: ${oidc.issuer_url}
+        clientID: ${oidc.client_id}
         clientSecret: $oidc.default.clientSecret
         requestedIDTokenClaims:
           groups:
@@ -126,8 +126,8 @@ keycloak:
       traefik.ingress.kubernetes.io/service.serversscheme: https
   keycloakClient:
     client:
-      clientId: ${client_id}
-      secret: ${client_secret}
+      clientId: ${oidc.client_id}
+      secret: ${oidc.client_secret}
       redirectUris:
         - https://argocd.apps.${base_domain}/auth/callback
         - https://argocd.apps.${cluster_name}.${base_domain}/auth/callback
@@ -138,7 +138,7 @@ keycloak:
         - https://alertmanager.apps.${base_domain}/oauth2/callback
         - https://alertmanager.apps.${cluster_name}.${base_domain}/oauth2/callback
   keycloakUser:
-    password: "${admin_password}"
+    password: "${keycloak.admin_password}"
 
 kube-prometheus-stack:
   alertmanager:
@@ -148,14 +148,14 @@ kube-prometheus-stack:
             - --http-address=0.0.0.0:9095
             - --upstream=http://localhost:9093
             - --provider=oidc
-            - --oidc-issuer-url=${oidc_issuer_url}
-            - --client-id=${client_id}
-            - --client-secret=${client_secret}
+            - --oidc-issuer-url=${oidc.issuer_url}
+            - --client-id=${oidc.client_id}
+            - --client-secret=${oidc.client_secret}
             - --cookie-secure=false
             - --cookie-secret=${cookie_secret}
             - --email-domain=*
             - --redirect-url=https://alertmanager.apps.${cluster_name}.${base_domain}/oauth2/callback
-            %{ for arg in oauth2_proxy_extra_args }
+            %{ for arg in oidc.oauth2_proxy_extra_args }
             - ${arg}
             %{ endfor }
           image: quay.io/pusher/oauth2_proxy:v6.1.1
@@ -185,13 +185,13 @@ kube-prometheus-stack:
       auth.generic_oauth:
         enabled: true
         allow_sign_up: true
-        client_id: ${client_id}
-        client_secret: ${client_secret}
+        client_id: ${oidc.client_id}
+        client_secret: ${oidc.client_secret}
         scopes: "openid profile email"
-        auth_url: ${oauth2_oauth_url}
-        token_url: ${oauth2_token_url}
-        api_url: ${oauth2_api_url}
-        %{ for k, v in grafana_generic_oauth_extra_args }
+        auth_url: ${oidc.oauth_url}
+        token_url: ${oidc.token_url}
+        api_url: ${oidc.api_url}
+        %{ for k, v in grafana.generic_oauth_extra_args }
         ${k}: ${v}
         %{ endfor }
       server:
@@ -249,14 +249,14 @@ kube-prometheus-stack:
             - --http-address=0.0.0.0:9091
             - --upstream=http://localhost:9090
             - --provider=oidc
-            - --oidc-issuer-url=${oidc_issuer_url}
-            - --client-id=${client_id}
-            - --client-secret=${client_secret}
+            - --oidc-issuer-url=${oidc.issuer_url}
+            - --client-id=${oidc.client_id}
+            - --client-secret=${oidc.client_secret}
             - --cookie-secure=false
             - --cookie-secret=${cookie_secret}
             - --email-domain=*
             - --redirect-url=https://prometheus.apps.${cluster_name}.${base_domain}/oauth2/callback
-            %{ for arg in oauth2_proxy_extra_args }
+            %{ for arg in oidc.oauth2_proxy_extra_args }
             - ${arg}
             %{ endfor }
           image: quay.io/pusher/oauth2_proxy:v6.1.1
@@ -276,10 +276,10 @@ loki-stack: {}
 
 metrics-server: {}
 
-%{ if enable_minio }
+%{ if minio.enable }
 minio:
-  accessKey: ${minio_access_key}
-  secretKey: ${minio_secret_key}
+  accessKey: ${minio.access_key}
+  secretKey: ${minio.secret_key}
   ingress:
     enabled: true
     annotations:
@@ -295,7 +295,7 @@ minio:
           - minio.apps.${base_domain}
           - minio.apps.${cluster_name}.${base_domain}
   buckets:
-    - name: ${loki_bucket_name}
+    - name: ${loki.bucket_name}
       policy: none
       purge: false
 %{ endif }

--- a/modules/aks-azure/main.tf
+++ b/modules/aks-azure/main.tf
@@ -71,55 +71,23 @@ module "cluster" {
 module "argocd" {
   source = "../argocd-helm"
 
-  client_secret = azuread_application_password.oauth2_apps.value
+  repo_url                        = var.repo_url
+  target_revision                 = var.target_revision
+  argocd_accounts_pipeline_tokens = module.argocd.argocd_accounts_pipeline_tokens
+  extra_apps                      = var.extra_apps
+  cluster_name                    = var.cluster_name
+  base_domain                     = var.base_domain
+  cluster_issuer                  = "letsencrypt-prod"
+  oidc                            = {
+    issuer_ul     = format("https://login.microsoftonline.com/%s/v2.0", data.azurerm_client_config.current.tenant_id)
+    oauth_url     = format("https://login.microsoftonline.com/%s/oauth2/authorize", data.azurerm_client_config.current.tenant_id)
+    token_url     = format("https://login.microsoftonline.com/%s/oauth2/token", data.azurerm_client_config.current.tenant_id)
+    api_url       = format("https://graph.microsoft.com/oidc/userinfo")
+    client_id     = azuread_application.oauth2_apps.application_id
+    client_secret = azuread_application_password.oauth2_apps.value
+  }
 
-  depends_on = [
-    module.cluster,
-  ]
-}
-
-resource "random_password" "oauth2_cookie_secret" {
-  length  = 16
-  special = false
-}
-
-resource "helm_release" "app_of_apps" {
-  name              = "app-of-apps"
-  chart             = "${path.module}/../../argocd/app-of-apps"
-  namespace         = "argocd"
-  dependency_update = true
-  create_namespace  = true
-
-  values = [
-    templatefile("${path.module}/../../argocd/app-of-apps/values.tmpl.yaml",
-      {
-        repo_url                        = var.repo_url
-        target_revision                 = var.target_revision
-        argocd_accounts_pipeline_tokens = module.argocd.argocd_accounts_pipeline_tokens
-        extra_apps                      = var.extra_apps
-        cluster_name                    = var.cluster_name
-        base_domain                     = var.base_domain
-        cluster_issuer                  = "letsencrypt-prod"
-        oidc_issuer_url                 = format("https://login.microsoftonline.com/%s/v2.0", data.azurerm_client_config.current.tenant_id)
-        oauth2_oauth_url                = format("https://login.microsoftonline.com/%s/oauth2/authorize", data.azurerm_client_config.current.tenant_id)
-        oauth2_token_url                = format("https://login.microsoftonline.com/%s/oauth2/token", data.azurerm_client_config.current.tenant_id)
-        oauth2_api_url                  = format("https://graph.microsoft.com/oidc/userinfo")
-        client_id                       = azuread_application.oauth2_apps.application_id
-        client_secret                   = azuread_application_password.oauth2_apps.value
-        cookie_secret                   = random_password.oauth2_cookie_secret.result
-        admin_password                  = ""
-        minio_access_key                = ""
-        minio_secret_key                = ""
-        loki_bucket_name                = "",
-        enable_efs                      = false
-        enable_keycloak                 = false
-        enable_olm                      = false
-        enable_minio                    = false
-
-        oauth2_proxy_extra_args          = []
-        grafana_generic_oauth_extra_args = {}
-      }
-    ),
+  app_of_apps_values_overrides = [
     templatefile("${path.module}/values.tmpl.yaml",
       {
         client_secret            = azuread_application_password.oauth2_apps.value
@@ -135,7 +103,7 @@ resource "helm_release" "app_of_apps" {
   ]
 
   depends_on = [
-    module.argocd,
+    module.cluster,
   ]
 }
 

--- a/modules/aks-azure/main.tf
+++ b/modules/aks-azure/main.tf
@@ -73,7 +73,6 @@ module "argocd" {
 
   repo_url                        = var.repo_url
   target_revision                 = var.target_revision
-  argocd_accounts_pipeline_tokens = module.argocd.argocd_accounts_pipeline_tokens
   extra_apps                      = var.extra_apps
   cluster_name                    = var.cluster_name
   base_domain                     = var.base_domain

--- a/modules/aks-azure/main.tf
+++ b/modules/aks-azure/main.tf
@@ -78,12 +78,13 @@ module "argocd" {
   base_domain                     = var.base_domain
   cluster_issuer                  = "letsencrypt-prod"
   oidc                            = {
-    issuer_ul     = format("https://login.microsoftonline.com/%s/v2.0", data.azurerm_client_config.current.tenant_id)
+    issuer_url    = format("https://login.microsoftonline.com/%s/v2.0", data.azurerm_client_config.current.tenant_id)
     oauth_url     = format("https://login.microsoftonline.com/%s/oauth2/authorize", data.azurerm_client_config.current.tenant_id)
     token_url     = format("https://login.microsoftonline.com/%s/oauth2/token", data.azurerm_client_config.current.tenant_id)
     api_url       = format("https://graph.microsoft.com/oidc/userinfo")
     client_id     = azuread_application.oauth2_apps.application_id
     client_secret = azuread_application_password.oauth2_apps.value
+    oauth2_proxy_extra_args = []
   }
 
   app_of_apps_values_overrides = [

--- a/modules/aks-azure/outputs.tf
+++ b/modules/aks-azure/outputs.tf
@@ -17,7 +17,7 @@ output "target_revision" {
 }
 
 output "app_of_apps_values" {
-  value = helm_release.app_of_apps.values
+  value = module.argocd.app_of_apps_values
 }
 
 output "node_resource_group" {

--- a/modules/argocd-helm/main.tf
+++ b/modules/argocd-helm/main.tf
@@ -53,3 +53,44 @@ resource "jwt_hashed_token" "argocd" {
   secret      = lookup(data.kubernetes_secret.argocd_secret.data, "server.secretkey")
   claims_json = jsonencode(local.jwt_token_payload)
 }
+
+resource "helm_release" "app_of_apps" {
+  name              = "app-of-apps"
+  chart             = "${path.module}/../../argocd/app-of-apps"
+  namespace         = "argocd"
+  dependency_update = true
+  create_namespace  = true
+
+  values = concat([
+    templatefile("${path.module}/../../argocd/app-of-apps/values.tmpl.yaml",
+      {
+        repo_url                         = var.repo_url
+        target_revision                  = var.target_revision
+        argocd_accounts_pipeline_tokens  = local.argocd_accounts_pipeline_tokens
+        extra_apps                       = var.extra_apps
+        cluster_name                     = var.cluster_name
+        base_domain                      = var.base_domain
+        cluster_issuer                   = var.cluster_issuer
+        oidc                             = var.oidc
+        cookie_secret                    = random_password.oauth2_cookie_secret.result
+        minio                            = var.minio
+        loki                             = var.loki
+        efs_provisioner                  = var.efs_provisioner
+        olm                              = var.olm
+        keycloak                         = var.keycloak
+        grafana                          = var.grafana
+      }
+    )],
+    var.app_of_apps_values_overrides,
+  )
+
+  depends_on = [
+    helm_release.argocd
+  ]
+}
+
+resource "random_password" "oauth2_cookie_secret" {
+  length  = 16
+  special = false
+}
+

--- a/modules/argocd-helm/main.tf
+++ b/modules/argocd-helm/main.tf
@@ -35,7 +35,7 @@ resource "helm_release" "argocd" {
       configs:
         secret:
           extra:
-            oidc.default.clientSecret: ${var.client_secret}
+            oidc.default.clientSecret: ${var.oidc.client_secret}
             accounts.pipeline.tokens: '${local.argocd_accounts_pipeline_tokens}'
     EOT
   ]

--- a/modules/argocd-helm/outputs.tf
+++ b/modules/argocd-helm/outputs.tf
@@ -1,9 +1,9 @@
-output "argocd_accounts_pipeline_tokens" {
-  description = "The token created for the pipeline."
-  value       = local.argocd_accounts_pipeline_tokens
-}
-
 output "argocd_auth_token" {
   description = "The token to set in ARGOCD_AUTH_TOKEN environment variable."
   value       = jwt_hashed_token.argocd.token
+}
+
+output "app_of_apps_values" {
+  description = "App of Apps values"
+  value       = helm_release.app_of_apps.values
 }

--- a/modules/argocd-helm/variables.tf
+++ b/modules/argocd-helm/variables.tf
@@ -1,3 +1,124 @@
-variable "client_secret" {
-  type = string
+variable "repo_url" {
+  description = "The source repo URL of ArgoCD's app of apps."
+  type        = string
+}
+
+variable "target_revision" {
+  description = "The source target revision of ArgoCD's app of apps."
+  type        = string
+}
+
+variable "extra_apps" {
+  description = "Extra applications to deploy."
+  type        = list
+  default     = []
+}
+
+variable "cluster_name" {
+  description = "The name of the cluster to create."
+  type        = string
+}
+
+variable "base_domain" {
+  description = "The base domain used for Ingresses."
+  type        = string
+}
+
+variable "cluster_issuer" {
+  description = "Cluster Issuer"
+  type        = string
+}
+
+variable "oidc" {
+  description = "OIDC Settings"
+  type        = object({
+    issuer_url              = string
+    oauth_url               = string
+    token_url               = string
+    api_url                 = string
+    oauth2_proxy_extra_args = list(string)
+    client_id               = string
+    client_secret           = string
+  })
+  default     = {
+    issuer_url              = ""
+    oauth_url               = ""
+    token_url               = ""
+    api_url                 = ""
+    client_id               = ""
+    client_secret           = ""
+    oauth2_proxy_extra_args = []
+  }
+}
+
+variable "grafana" {
+  description = "Grafana settings"
+  type        = object({
+    generic_oauth_extra_args = map(any)
+  })
+  default     = {
+    generic_oauth_extra_args = {}
+  }
+}
+
+variable "loki" {
+  description = "Loki settings"
+  type = object({
+    bucket_name = string
+  })
+  default = {
+    bucket_name = ""
+  } 
+}
+
+variable "efs_provisioner" {
+  description = "EFS provisioner settings"
+  type        = object({
+    enable = bool
+  })
+  default     = {
+    enable = false
+  } 
+}
+
+variable "keycloak" {
+  description = "Keycloak settings"
+  type        = object({
+    enable         = bool
+    admin_password = string
+  })
+  default     = {
+    enable         = false
+    admin_password = ""
+  } 
+}
+
+variable "olm" {
+  description = "OLM settings"
+  type        = object({
+    enable = bool
+  })
+  default     = {
+    enable = false
+  }
+}
+
+variable "minio" {
+  description = "Minio settings"
+  type        = object({
+    enable     = bool
+    access_key = string
+    secret_key = string
+  })
+  default = {
+    enable     = false
+    access_key = ""
+    secret_key = ""
+  }
+}
+
+variable "app_of_apps_values_overrides" {
+  description = "Extra value files content for the App of Apps"
+  type        = list(string)
+  default     = []
 }

--- a/modules/eks-aws/main.tf
+++ b/modules/eks-aws/main.tf
@@ -122,55 +122,30 @@ resource "aws_security_group_rule" "workers_ingress_healthcheck_http" {
 module "argocd" {
   source = "../argocd-helm"
 
-  client_secret = aws_cognito_user_pool_client.client.client_secret
+  repo_url        = var.repo_url
+  target_revision = var.target_revision
+  extra_apps      = var.extra_apps
+  cluster_name    = var.cluster_name
+  base_domain     = var.base_domain
 
-  depends_on = [
-    module.cluster,
-  ]
-}
+  cluster_issuer   = "letsencrypt-prod"
+  oidc             = {
+    issuer_url              = format("https://cognito-idp.%s.amazonaws.com/%s", data.aws_region.current.name, var.cognito_user_pool_id)
+    oauth_url               = format("https://%s.auth.%s.amazoncognito.com/oauth2/authorize", var.cognito_user_pool_domain, data.aws_region.current.name)
+    token_url               = format("https://%s.auth.%s.amazoncognito.com/oauth2/token", var.cognito_user_pool_domain, data.aws_region.current.name)
+    api_url                 = format("https://%s.auth.%s.amazoncognito.com/oauth2/userInfo", var.cognito_user_pool_domain, data.aws_region.current.name)
+    client_id               = aws_cognito_user_pool_client.client.id
+    client_secret           = aws_cognito_user_pool_client.client.client_secret
+    oauth2_proxy_extra_args = []
+  }
+  loki             = {
+    bucket_name = aws_s3_bucket.loki.id,
+  }
+  efs_provisioner  = {
+    enable = var.enable_efs
+  }
 
-resource "random_password" "oauth2_cookie_secret" {
-  length  = 16
-  special = false
-}
-
-resource "helm_release" "app_of_apps" {
-  name              = "app-of-apps"
-  chart             = "${path.module}/../../argocd/app-of-apps"
-  namespace         = "argocd"
-  dependency_update = true
-  create_namespace  = true
-
-  values = [
-    templatefile("${path.module}/../../argocd/app-of-apps/values.tmpl.yaml",
-      {
-        repo_url                        = var.repo_url
-        target_revision                 = var.target_revision
-        argocd_accounts_pipeline_tokens = module.argocd.argocd_accounts_pipeline_tokens
-        extra_apps                      = var.extra_apps
-        cluster_name                    = var.cluster_name
-        base_domain                     = var.base_domain
-        cluster_issuer                  = "letsencrypt-prod"
-        oidc_issuer_url                 = format("https://cognito-idp.%s.amazonaws.com/%s", data.aws_region.current.name, var.cognito_user_pool_id)
-        oauth2_oauth_url                = format("https://%s.auth.%s.amazoncognito.com/oauth2/authorize", var.cognito_user_pool_domain, data.aws_region.current.name)
-        oauth2_token_url                = format("https://%s.auth.%s.amazoncognito.com/oauth2/token", var.cognito_user_pool_domain, data.aws_region.current.name)
-        oauth2_api_url                  = format("https://%s.auth.%s.amazoncognito.com/oauth2/userInfo", var.cognito_user_pool_domain, data.aws_region.current.name)
-        client_id                       = aws_cognito_user_pool_client.client.id
-        client_secret                   = aws_cognito_user_pool_client.client.client_secret
-        cookie_secret                   = random_password.oauth2_cookie_secret.result
-        admin_password                  = ""
-        minio_access_key                = ""
-        minio_secret_key                = ""
-        loki_bucket_name                = aws_s3_bucket.loki.id,
-        enable_efs                      = var.enable_efs
-        enable_keycloak                 = false
-        enable_olm                      = false
-        enable_minio                    = false
-
-        oauth2_proxy_extra_args          = []
-        grafana_generic_oauth_extra_args = {}
-      }
-    ),
+  app_of_apps_values_overrides = [
     templatefile("${path.module}/values.tmpl.yaml",
       {
         aws_default_region              = data.aws_region.current.name
@@ -185,6 +160,6 @@ resource "helm_release" "app_of_apps" {
   ]
 
   depends_on = [
-    module.argocd,
+    module.cluster,
   ]
 }

--- a/modules/eks-aws/outputs.tf
+++ b/modules/eks-aws/outputs.tf
@@ -17,7 +17,7 @@ output "target_revision" {
 }
 
 output "app_of_apps_values" {
-  value = helm_release.app_of_apps.values
+  value = module.argocd.app_of_apps_values
 }
 
 # Specific outputs

--- a/modules/k3os-libvirt/main.tf
+++ b/modules/k3os-libvirt/main.tf
@@ -40,56 +40,49 @@ module "cluster" {
 module "argocd" {
   source = "../argocd-helm"
 
-  client_secret = random_password.clientsecret.result
+  repo_url                        = var.repo_url
+  target_revision                 = var.target_revision
+  extra_apps                      = var.extra_apps
+  cluster_name                    = var.cluster_name
+  base_domain                     = local.base_domain
+  cluster_issuer                  = "ca-issuer"
+  oidc                            = {
+    issuer_url              = format("https://keycloak.apps.%s/auth/realms/kubernetes", local.base_domain)
+    oauth_url               = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/auth", local.base_domain)
+    token_url               = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/token", local.base_domain)
+    api_url                 = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/userinfo", local.base_domain)
+    client_id               = "applications"
+    client_secret           = random_password.clientsecret.result
+    oauth2_proxy_extra_args = []
+  }
+  minio                           = {
+    enable     = var.enable_minio
+    access_key = var.enable_minio ? random_password.minio_accesskey.0.result : ""
+    secret_key = var.enable_minio ? random_password.minio_secretkey.0.result : ""
+  }
+  keycloak                        = {
+    enable         = true
+    admin_password = random_password.admin_password.result
+  }
+  loki                            = {
+    bucket_name = "loki"
+  }
+  olm                             = {
+    enable = true
+  }
 
-  depends_on = [
-    module.cluster,
+  oauth2_proxy_extra_args = [
+    "--insecure-oidc-skip-issuer-verification=true",
+    "--ssl-insecure-skip-verify=true",
   ]
-}
 
-resource "helm_release" "app_of_apps" {
-  name              = "app-of-apps"
-  chart             = "${path.module}/../../argocd/app-of-apps"
-  namespace         = "argocd"
-  dependency_update = true
-  create_namespace  = true
+  grafana = {
+    generic_oauth_extra_args = {
+      tls_skip_verify_insecure = true
+    }
+  }
 
-  values = [
-    templatefile("${path.module}/../../argocd/app-of-apps/values.tmpl.yaml",
-      {
-        repo_url                        = var.repo_url
-        target_revision                 = var.target_revision
-        argocd_accounts_pipeline_tokens = module.argocd.argocd_accounts_pipeline_tokens
-        extra_apps                      = var.extra_apps
-        cluster_name                    = var.cluster_name
-        base_domain                     = local.base_domain
-        cluster_issuer                  = "ca-issuer"
-        oidc_issuer_url                 = format("https://keycloak.apps.%s/auth/realms/kubernetes", local.base_domain)
-        oauth2_oauth_url                = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/auth", local.base_domain)
-        oauth2_token_url                = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/token", local.base_domain)
-        oauth2_api_url                  = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/userinfo", local.base_domain)
-        client_id                       = "applications"
-        client_secret                   = random_password.clientsecret.result
-        cookie_secret                   = random_password.oauth2_cookie_secret.result
-        admin_password                  = random_password.admin_password.result
-        minio_access_key                = var.enable_minio ? random_password.minio_accesskey.0.result : ""
-        minio_secret_key                = var.enable_minio ? random_password.minio_secretkey.0.result : ""
-        loki_bucket_name                = "loki"
-        enable_efs                      = false
-        enable_keycloak                 = true
-        enable_olm                      = true
-        enable_minio                    = var.enable_minio
-
-        oauth2_proxy_extra_args = [
-          "--insecure-oidc-skip-issuer-verification=true",
-          "--ssl-insecure-skip-verify=true",
-        ]
-
-        grafana_generic_oauth_extra_args = {
-          tls_skip_verify_insecure = true
-        }
-      }
-    ),
+  app_of_apps_values_overrides    = [
     templatefile("${path.module}/values.tmpl.yaml",
       {
         root_cert = base64encode(tls_self_signed_cert.root.cert_pem)
@@ -100,7 +93,7 @@ resource "helm_release" "app_of_apps" {
   ]
 
   depends_on = [
-    module.argocd,
+    module.cluster,
   ]
 }
 
@@ -110,11 +103,6 @@ resource "random_password" "clientsecret" {
 }
 
 resource "random_password" "admin_password" {
-  length  = 16
-  special = false
-}
-
-resource "random_password" "oauth2_cookie_secret" {
   length  = 16
   special = false
 }

--- a/modules/k3os-libvirt/main.tf
+++ b/modules/k3os-libvirt/main.tf
@@ -53,7 +53,10 @@ module "argocd" {
     api_url                 = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/userinfo", local.base_domain)
     client_id               = "applications"
     client_secret           = random_password.clientsecret.result
-    oauth2_proxy_extra_args = []
+    oauth2_proxy_extra_args = [
+      "--insecure-oidc-skip-issuer-verification=true",
+      "--ssl-insecure-skip-verify=true",
+    ]
   }
   minio                           = {
     enable     = var.enable_minio
@@ -70,11 +73,6 @@ module "argocd" {
   olm                             = {
     enable = true
   }
-
-  oauth2_proxy_extra_args = [
-    "--insecure-oidc-skip-issuer-verification=true",
-    "--ssl-insecure-skip-verify=true",
-  ]
 
   grafana = {
     generic_oauth_extra_args = {

--- a/modules/k3os-libvirt/outputs.tf
+++ b/modules/k3os-libvirt/outputs.tf
@@ -17,7 +17,7 @@ output "target_revision" {
 }
 
 output "app_of_apps_values" {
-  value = helm_release.app_of_apps.values
+  value = module.argocd.app_of_apps_values
 }
 
 # Specific outputs

--- a/modules/k3s-docker/main.tf
+++ b/modules/k3s-docker/main.tf
@@ -42,56 +42,49 @@ module "cluster" {
 module "argocd" {
   source = "../argocd-helm"
 
-  client_secret = random_password.clientsecret.result
+  repo_url                        = var.repo_url
+  target_revision                 = var.target_revision
+  extra_apps                      = var.extra_apps
+  cluster_name                    = var.cluster_name
+  base_domain                     = local.base_domain
+  cluster_issuer                  = "ca-issuer"
+  oidc                            = {
+    issuer_url              = format("https://keycloak.apps.%s/auth/realms/kubernetes", local.base_domain)
+    oauth_url               = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/auth", local.base_domain)
+    token_url               = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/token", local.base_domain)
+    api_url                 = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/userinfo", local.base_domain)
+    client_id               = "applications"
+    client_secret           = random_password.clientsecret.result
+    oauth2_proxy_extra_args = []
+  }
+  minio                           = {
+    enable     = var.enable_minio
+    access_key = var.enable_minio ? random_password.minio_accesskey.0.result : ""
+    secret_key = var.enable_minio ? random_password.minio_secretkey.0.result : ""
+  }
+  keycloak                        = {
+    enable         = true
+    admin_password = random_password.admin_password.result
+  }
+  loki                            = {
+    bucket_name = "loki"
+  }
+  olm                             = {
+    enable = true
+  }
 
-  depends_on = [
-    module.cluster,
+  oauth2_proxy_extra_args = [
+    "--insecure-oidc-skip-issuer-verification=true",
+    "--ssl-insecure-skip-verify=true",
   ]
-}
 
-resource "helm_release" "app_of_apps" {
-  name              = "app-of-apps"
-  chart             = "${path.module}/../../argocd/app-of-apps"
-  namespace         = "argocd"
-  dependency_update = true
-  create_namespace  = true
+  grafana = {
+    generic_oauth_extra_args = {
+      tls_skip_verify_insecure = true
+    }
+  }
 
-  values = [
-    templatefile("${path.module}/../../argocd/app-of-apps/values.tmpl.yaml",
-      {
-        repo_url                        = var.repo_url
-        target_revision                 = var.target_revision
-        argocd_accounts_pipeline_tokens = module.argocd.argocd_accounts_pipeline_tokens
-        extra_apps                      = var.extra_apps
-        cluster_name                    = var.cluster_name
-        base_domain                     = local.base_domain
-        cluster_issuer                  = "ca-issuer"
-        oidc_issuer_url                 = format("https://keycloak.apps.%s/auth/realms/kubernetes", local.base_domain)
-        oauth2_oauth_url                = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/auth", local.base_domain)
-        oauth2_token_url                = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/token", local.base_domain)
-        oauth2_api_url                  = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/userinfo", local.base_domain)
-        client_id                       = "applications"
-        client_secret                   = random_password.clientsecret.result
-        cookie_secret                   = random_password.oauth2_cookie_secret.result
-        admin_password                  = random_password.admin_password.result
-        minio_access_key                = var.enable_minio ? random_password.minio_accesskey.0.result : ""
-        minio_secret_key                = var.enable_minio ? random_password.minio_secretkey.0.result : ""
-        loki_bucket_name                = "loki"
-        enable_efs                      = false
-        enable_keycloak                 = true
-        enable_olm                      = true
-        enable_minio                    = var.enable_minio
-
-        oauth2_proxy_extra_args = [
-          "--insecure-oidc-skip-issuer-verification=true",
-          "--ssl-insecure-skip-verify=true",
-        ]
-
-        grafana_generic_oauth_extra_args = {
-          tls_skip_verify_insecure = true
-        }
-      }
-    ),
+  app_of_apps_values_overrides    = [
     templatefile("${path.module}/values.tmpl.yaml",
       {
         root_cert = base64encode(tls_self_signed_cert.root.cert_pem)
@@ -102,9 +95,10 @@ resource "helm_release" "app_of_apps" {
   ]
 
   depends_on = [
-    module.argocd,
+    module.cluster,
   ]
 }
+
 
 resource "random_password" "clientsecret" {
   length  = 16
@@ -112,11 +106,6 @@ resource "random_password" "clientsecret" {
 }
 
 resource "random_password" "admin_password" {
-  length  = 16
-  special = false
-}
-
-resource "random_password" "oauth2_cookie_secret" {
   length  = 16
   special = false
 }

--- a/modules/k3s-docker/main.tf
+++ b/modules/k3s-docker/main.tf
@@ -55,7 +55,10 @@ module "argocd" {
     api_url                 = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/userinfo", local.base_domain)
     client_id               = "applications"
     client_secret           = random_password.clientsecret.result
-    oauth2_proxy_extra_args = []
+    oauth2_proxy_extra_args = [
+      "--insecure-oidc-skip-issuer-verification=true",
+      "--ssl-insecure-skip-verify=true",
+    ]
   }
   minio                           = {
     enable     = var.enable_minio
@@ -72,11 +75,6 @@ module "argocd" {
   olm                             = {
     enable = true
   }
-
-  oauth2_proxy_extra_args = [
-    "--insecure-oidc-skip-issuer-verification=true",
-    "--ssl-insecure-skip-verify=true",
-  ]
 
   grafana = {
     generic_oauth_extra_args = {

--- a/modules/k3s-docker/outputs.tf
+++ b/modules/k3s-docker/outputs.tf
@@ -17,7 +17,7 @@ output "target_revision" {
 }
 
 output "app_of_apps_values" {
-  value = helm_release.app_of_apps.values
+  value = module.argocd.app_of_apps_values
 }
 
 # Specific outputs


### PR DESCRIPTION
This puts the app of apps helm release inside the argocd-helm module, and refactors the variables for more clarity.

It supersedes #340 