### PR TITLE
Extending default memory to 8Gb for better stability

### DIFF
--- a/tests/k3s-libvirt/terraform/main.tf
+++ b/tests/k3s-libvirt/terraform/main.tf
@@ -6,7 +6,7 @@ module "cluster" {
 
   repo_url        = var.repo_url
   target_revision = var.target_revision
-
+  server_memory   = 8192
   extra_apps = [
     {
       metadata = {


### PR DESCRIPTION
The memory for the server is set by default to 2048Mb but it isn't enough for the whole stack. This is why I suggest to extend it to 8Gb. Intermediate stage 4Gb doesn't offer enough stability and many pods are crashing due to OOM