### PR TITLE
Allow to pass ArgoCD's Server SecretKey

### DIFF
--- a/argocd/app-of-apps/values.tmpl.yaml
+++ b/argocd/app-of-apps/values.tmpl.yaml
@@ -50,6 +50,7 @@ argo-cd:
       extra:
         oidc.default.clientSecret: ${oidc.client_secret}
         accounts.pipeline.tokens: '${argocd_accounts_pipeline_tokens}'
+        server.secretkey: ${argocd_server_secretkey}
   controller:
     metrics:
       enabled: true

--- a/modules/aks/azure/main.tf
+++ b/modules/aks/azure/main.tf
@@ -74,13 +74,14 @@ module "cluster" {
 module "argocd" {
   source = "../../argocd-helm"
 
-  kubeconfig      = local.kubeconfig
-  repo_url        = var.repo_url
-  target_revision = var.target_revision
-  extra_apps      = var.extra_apps
-  cluster_name    = var.cluster_name
-  base_domain     = var.base_domain
-  cluster_issuer  = "letsencrypt-prod"
+  kubeconfig              = local.kubeconfig
+  repo_url                = var.repo_url
+  target_revision         = var.target_revision
+  extra_apps              = var.extra_apps
+  cluster_name            = var.cluster_name
+  base_domain             = var.base_domain
+  cluster_issuer          = "letsencrypt-prod"
+  argocd_server_secretkey = var.argocd_server_secretkey
 
   oidc = var.oidc != null ? var.oidc : {
     issuer_url    = format("https://login.microsoftonline.com/%s/v2.0", data.azurerm_client_config.current.tenant_id)

--- a/modules/argocd-helm/variables.tf
+++ b/modules/argocd-helm/variables.tf
@@ -19,6 +19,12 @@ variable "extra_apps" {
   default     = []
 }
 
+variable "argocd_server_secretkey" {
+  description = "ArgoCD Server Secert Key to avoid regenerate token on redeploy."
+  type        = string
+  default     = null
+}
+
 variable "cluster_name" {
   description = "The name of the cluster to create."
   type        = string

--- a/modules/eks/aws/main.tf
+++ b/modules/eks/aws/main.tf
@@ -105,12 +105,13 @@ resource "aws_security_group_rule" "workers_ingress_healthcheck_http" {
 module "argocd" {
   source = "../../argocd-helm"
 
-  kubeconfig      = local.kubeconfig
-  repo_url        = var.repo_url
-  target_revision = var.target_revision
-  extra_apps      = var.extra_apps
-  cluster_name    = var.cluster_name
-  base_domain     = var.base_domain
+  kubeconfig              = local.kubeconfig
+  repo_url                = var.repo_url
+  target_revision         = var.target_revision
+  extra_apps              = var.extra_apps
+  cluster_name            = var.cluster_name
+  base_domain             = var.base_domain
+  argocd_server_secretkey = var.argocd_server_secretkey
 
   cluster_issuer = "letsencrypt-prod"
   oidc = var.oidc != null ? var.oidc : {

--- a/modules/k3s/main.tf
+++ b/modules/k3s/main.tf
@@ -31,13 +31,15 @@ provider "kubernetes" {
 module "argocd" {
   source = "../../argocd-helm"
 
-  kubeconfig      = local.kubeconfig
-  repo_url        = var.repo_url
-  target_revision = var.target_revision
-  extra_apps      = var.extra_apps
-  cluster_name    = var.cluster_name
-  base_domain     = local.base_domain
-  cluster_issuer  = "ca-issuer"
+  kubeconfig              = local.kubeconfig
+  repo_url                = var.repo_url
+  target_revision         = var.target_revision
+  extra_apps              = var.extra_apps
+  cluster_name            = var.cluster_name
+  base_domain             = local.base_domain
+  argocd_server_secretkey = var.argocd_server_secretkey
+
+  cluster_issuer = "ca-issuer"
   oidc = var.oidc != null ? var.oidc : {
     issuer_url    = format("https://keycloak.apps.%s/auth/realms/kubernetes", local.base_domain)
     oauth_url     = format("https://keycloak.apps.%s/auth/realms/kubernetes/protocol/openid-connect/auth", local.base_domain)

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -40,3 +40,9 @@ variable "oidc" {
   })
   default = null
 }
+
+variable "argocd_server_secretkey" {
+  description = "ArgoCD Server Secert Key to avoid regenerate token on redeploy."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This is useful when you want your ArgoCD token to still be valid on
redeploy.