### PR TITLE
Making components to be enabled or not

### DIFF
--- a/argocd/app-of-apps/values.tmpl.yaml
+++ b/argocd/app-of-apps/values.tmpl.yaml
@@ -18,7 +18,7 @@ apps:
   argocd:
     enabled: true
   cert-manager:
-    enabled: true
+    enabled: ${cert_manager.enable}
   csi-secrets-store-provider-azure:
     enabled: false
   efs-provisioner:
@@ -26,11 +26,11 @@ apps:
   keycloak:
     enabled: ${keycloak.enable}
   kube-prometheus-stack:
-    enabled: true
+    enabled: ${kube_prometheus_stack.enable}
   loki-stack:
-    enabled: true
+    enabled: ${loki.enable}
   metrics-server:
-    enabled: true
+    enabled: ${metrics_server.enable}
   minio:
     enabled: ${minio.enable}
   namespaces:
@@ -38,7 +38,7 @@ apps:
   secrets-store-csi-driver:
     enabled: false
   traefik:
-    enabled: true
+    enabled: ${traefik.enable}
   vault:
     enabled: false
 
@@ -99,10 +99,15 @@ argo-cd:
         g, argocd-admin, role:admin
       scopes: '[groups, cognito:groups, roles]'
 
+%{ if cert_manager.enable }
 cert-manager: {}
+%{ endif }
 
+%{ if efs_provisioner.enable }
 efs-provisioner: {}
+%{ endif }
 
+%{ if keycloak.enable }
 keycloak:
   ingress:
     enabled: true
@@ -142,9 +147,13 @@ keycloak:
         - https://${alertmanager.domain}/oauth2/callback
   keycloakUser:
     password: "${keycloak.admin_password}"
+%{ endif }
 
+%{ if kube_prometheus_stack.enable }
 kube-prometheus-stack:
   alertmanager:
+    enabled: ${ alertmanager.enable }
+%{ if alertmanager.enable }  
     alertmanagerSpec:
       containers:
         - args:
@@ -186,8 +195,11 @@ kube-prometheus-stack:
       targetPort: 9095
     serviceMonitor:
       selfMonitor: false
+%{ endif }  # alertmanager config    
 
   grafana:
+    enabled: ${grafana.enable}
+%{ if grafana.enable }
     grafana.ini:
       auth.generic_oauth:
         enabled: true
@@ -235,8 +247,11 @@ kube-prometheus-stack:
           hosts:
             - grafana.apps.${base_domain}
             - ${grafana.domain}
+%{ endif } # Grafana config
 
   prometheus:
+    enabled: ${prometheus.enable}
+%{ if prometheus.enable }
     ingress:
       enabled: true
       annotations:
@@ -320,9 +335,16 @@ kube-prometheus-stack:
 %{ if can(metrics_archives.bucket_config) }
   ${ indent(4,yamlencode({"thanosObjectStorageConfig": metrics_archives.bucket_config})) }
 %{ endif }
-loki-stack: {}
+%{ endif } # Prometheus config
+%{ endif } # kube-prometheus-stack config
 
+%{ if loki.enable }
+loki-stack: {}
+%{ endif }
+
+%{ if metrics_server.enable}
 metrics-server: {}
+%{ endif }
 
 %{ if minio.enable }
 minio:
@@ -355,6 +377,8 @@ minio:
 
 secrets-store-csi-driver: {}
 
+%{ if traefik.enable }
 traefik: {}
+%{ endif }
 
 vault: {}

--- a/modules/argocd-helm/local.tf
+++ b/modules/argocd-helm/local.tf
@@ -22,6 +22,7 @@ locals {
   )
 
   grafana_defaults = {
+    enable                   = true
     generic_oauth_extra_args = {}
     domain                   = "grafana.apps.${var.cluster_name}.${var.base_domain}"
   }
@@ -29,9 +30,16 @@ locals {
     local.grafana_defaults,
     var.grafana,
   )
-
+  metrics_server_defaults = {
+    enable = true
+  }
+  metrics_server = merge(
+    local.metrics_server_defaults,
+    var.metrics_server,
+  )
   prometheus_defaults = {
     domain = "prometheus.apps.${var.cluster_name}.${var.base_domain}"
+    enable = true
   }
   prometheus = merge(
     local.prometheus_defaults,
@@ -39,15 +47,24 @@ locals {
   )
 
   alertmanager_defaults = {
+    enable = true
     domain = "alertmanager.apps.${var.cluster_name}.${var.base_domain}"
   }
   alertmanager = merge(
     local.alertmanager_defaults,
     var.alertmanager,
   )
+  traefik_defaults = {
+    enable = true
+  }
+  traefik = merge(
+    local.traefik_defaults,
+    var.traefik,
+  )
 
   loki_defaults = {
     bucket_name = ""
+    enable = true
   }
   loki = merge(
     local.loki_defaults,
@@ -88,5 +105,19 @@ locals {
   metrics_archives = merge(
     local.metrics_archives_defaults,
     var.metrics_archives,
+  )
+  cert_manager_defaults = {
+    enable = true
+  }
+  cert_manager = merge(
+    local.cert_manager_defaults,
+    var.cert_manager,
+  ) 
+  kube_prometheus_stack_defaults = {
+    enable = true
+  }
+  kube_prometheus_stack = merge(
+    local.kube_prometheus_stack_defaults,
+    var.kube_prometheus_stack,
   )
 }

--- a/modules/argocd-helm/main.tf
+++ b/modules/argocd-helm/main.tf
@@ -80,13 +80,17 @@ resource "helm_release" "app_of_apps" {
         cookie_secret                   = random_password.oauth2_cookie_secret.result
         minio                           = local.minio
         loki                            = local.loki
+        traefik                         = local.traefik
         efs_provisioner                 = local.efs_provisioner
         argocd                          = local.argocd
         keycloak                        = local.keycloak
         grafana                         = local.grafana
         prometheus                      = local.prometheus
         alertmanager                    = local.alertmanager
+        metrics_server                  = local.metrics_server
         metrics_archives                = local.metrics_archives
+        cert_manager                    = local.cert_manager
+        kube_prometheus_stack           = local.kube_prometheus_stack
       }
     )],
     var.app_of_apps_values_overrides,

--- a/modules/argocd-helm/variables.tf
+++ b/modules/argocd-helm/variables.tf
@@ -70,6 +70,12 @@ variable "loki" {
   default     = {}
 }
 
+variable "traefik" {
+  description = "Trafik settings"
+  type        = any
+  default     = {}
+}
+
 variable "efs_provisioner" {
   description = "EFS provisioner settings"
   type        = any
@@ -94,8 +100,26 @@ variable "app_of_apps_values_overrides" {
   default     = []
 }
 
+variable "metrics_server" {
+  description = "Metrics server settings"
+  type        = any
+  default     = {}
+}
+
 variable "metrics_archives" {
   description = "Metrics archives settings"
+  type        = any
+  default     = {}
+}
+
+variable "cert_manager" {
+  description = "Cert Manager settings"
+  type        = any
+  default     = {}
+}
+
+variable "kube_prometheus_stack" {
+  description = "Kube-prometheus-stack settings"
   type        = any
   default     = {}
 }


### PR DESCRIPTION
For the future integration of OCP4, we need to be able to enable/disable basic Kubernetes components as they're already available in OCP (such as ingress controller, prometheus etc)