### PR TITLE
Don't depend on Terraform workspaces

### DIFF
--- a/.gitlab-ci/pipeline.yaml
+++ b/.gitlab-ci/pipeline.yaml
@@ -18,8 +18,6 @@ mr:terraform:plan:
   image:
     name: hashicorp/terraform:$TERRAFORM_VERSION
     entrypoint: [""]
-  variables:
-    TF_WORKSPACE: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
   before_script:
     - wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /tmp/jq
     - chmod +x /tmp/jq
@@ -92,36 +90,7 @@ pb:terraform:apply:
   script:
     - cd "$TF_ROOT"
     - terraform init
-    - terraform workspace select "$CI_COMMIT_REF_NAME" || terraform workspace new "$CI_COMMIT_REF_NAME"
-    - terraform init
     - terraform apply --auto-approve
     - terraform plan --detailed-exitcode
-  environment:
-    name: cluster/$CI_COMMIT_REF_NAME
-    on_stop: pb:terraform:destroy
   rules:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-
-###
-# On-stop action for Gitlab CI environment
-#
-
-pb:terraform:destroy:
-  stage: terraform
-  image:
-    name: hashicorp/terraform:$TERRAFORM_VERSION
-    entrypoint: [""]
-  variables:
-    TF_WORKSPACE: $CI_COMMIT_REF_NAME
-  script:
-    - cd "$TF_ROOT"
-    - terraform init
-    - terraform destroy --auto-approve
-    - if [ "$TF_WORKSPACE" != "default" ]; then WORKSPACE="$TF_WORKSPACE"; unset TF_WORKSPACE; terraform workspace select default; terraform workspace delete "$WORKSPACE"; fi
-  environment:
-    name: cluster/$CI_COMMIT_REF_NAME
-    action: stop
-  allow_failure: true
-  rules:
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: manual

--- a/docs/modules/ROOT/pages/howtos/quickstart_aks.adoc
+++ b/docs/modules/ROOT/pages/howtos/quickstart_aks.adoc
@@ -21,7 +21,7 @@ Here is a minimal working example:
 # terraform/main.tf
 
 locals {
-  cluster_name = terraform.workspace
+  cluster_name = "my-cluster"
 }
 resource "azurerm_resource_group" "this" {
   name     = local.cluster_name

--- a/docs/modules/ROOT/pages/howtos/quickstart_eks.adoc
+++ b/docs/modules/ROOT/pages/howtos/quickstart_eks.adoc
@@ -21,7 +21,7 @@ Here is a minimal working example:
 # terraform/main.tf
 
 locals {
-  cluster_name = terraform.workspace
+  cluster_name = "my-cluster"
 }
 
 data "aws_availability_zones" "available" {}
@@ -105,26 +105,8 @@ include::partial$deploy_workstation.adoc[]
 
 == Deploying from pipelines
 
-When using pipelines, the DevOps Stack creates one Kubernetes cluster per protected branch.
-Each cluster's state is saved in a separate
-https://www.terraform.io/docs/language/state/workspaces.html[Terraform workspace].
-
-
-NOTE: On GitLab, the DevOps Stack creates one
-https://docs.gitlab.com/ee/ci/environments/[GitLab CI Environment] per cluster.
-This links the cluster’s lifecycle to the GitLab environment.
-In particular, it allows to automatically destroy a cluster when the
-associated branch is deleted or the environment is stopped.
-
-1 protected branch == 1 Kubernetes cluster == 1 Terraform workspace (== 1 GitLab environment)
-
-This behavior allows you to either have one cluster per line (prod, qa, int, dev…)
-or adopt a blue/green infrastructure philosophy.
-Of course, if you want to share some resources between multiple clusters,
-a VPC and RDS cluster or whatever stateful resources,
-you should define them in a separated Terraform project and use datasources
-to lookup them in the cluster Terraform project.
-
+When using pipelines, the DevOps Stack runs a dry-run on Merge Request and applies
+the modification on commit on a protected branch.
 
 include::partial$pipelines_gitlab.adoc[ci-variables, terraform-provider, terraform-provider-link]
 

--- a/examples/eks-aws/.github/workflows/terraform.yml
+++ b/examples/eks-aws/.github/workflows/terraform.yml
@@ -28,16 +28,6 @@ jobs:
         with:
           terraform_version: 0.14.6
 
-      - name: Set Terraform workspace
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: echo "TF_WORKSPACE=${{ github.base_ref }}" >> $GITHUB_ENV
-
-      - name: Set Terraform workspace
-        if: github.event_name == 'push'
-        shell: bash
-        run: echo "TF_WORKSPACE=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-
       - name: Terraform Format
         run: terraform fmt -check -diff -recursive
 

--- a/examples/eks-aws/terraform/main.tf
+++ b/examples/eks-aws/terraform/main.tf
@@ -25,7 +25,7 @@ data "aws_iam_role" "eks_admin" {
 module "cluster" {
   source = "git::https://github.com/camptocamp/camptocamp-devops-stack.git//modules/eks/aws?ref=v0.28.0"
 
-  cluster_name                         = terraform.workspace
+  cluster_name                         = "my-cluster"
   cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
   vpc_id                               = data.aws_vpc.this.id
 

--- a/examples/k3s-docker-demo-app/terraform/main.tf
+++ b/examples/k3s-docker-demo-app/terraform/main.tf
@@ -10,7 +10,7 @@ locals {
 module "cluster" {
   source = "git::https://github.com/camptocamp/camptocamp-devops-stack.git//modules/k3s/docker?ref=v0.28.0"
 
-  cluster_name = terraform.workspace
+  cluster_name = "my-cluster"
   node_count   = 1
 
   extra_apps = [

--- a/examples/k3s-libvirt-demo-app/terraform/main.tf
+++ b/examples/k3s-libvirt-demo-app/terraform/main.tf
@@ -10,7 +10,7 @@ locals {
 module "cluster" {
   source = "git::https://github.com/camptocamp/camptocamp-devops-stack.git//modules/k3s/libvirt?ref=v0.28.0"
 
-  cluster_name = terraform.workspace
+  cluster_name = "my-cluster"
   node_count   = 1
 
   extra_apps = [

--- a/tests/k3s-docker/terraform/main.tf
+++ b/tests/k3s-docker/terraform/main.tf
@@ -1,7 +1,7 @@
 module "cluster" {
   source = "../../../modules/k3s/docker"
 
-  cluster_name = terraform.workspace
+  cluster_name = "default"
   node_count   = 1
 
   repo_url        = var.repo_url

--- a/tests/k3s-libvirt/terraform/main.tf
+++ b/tests/k3s-libvirt/terraform/main.tf
@@ -1,7 +1,7 @@
 module "cluster" {
   source = "../../../modules/k3s/libvirt"
 
-  cluster_name = terraform.workspace
+  cluster_name = "default"
   node_count   = 0
 
   repo_url        = var.repo_url


### PR DESCRIPTION
Now that almost everything is done in Terraform, we don't depend on Terraform workspaces anymore (of course we can still use it, but we don't depend on it).
This simplifies a bit the process as we don't have to explain how Terraform workspaces works and allows the DevOps Stack to be deployed with a single git repository instead of one for statefull resources and one for stateless resources.